### PR TITLE
Update service environment variables.

### DIFF
--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -41,6 +41,8 @@ spec:
               value: "ppcentralbutler"
             - name: USER_REGISTRY
               value: "pp"
+            - name: KAFKA_CLUSTER
+              value: prompt-processing-kafka-bootstrap.kafka:9092
             - name: PSQL_REGISTRY_PASS
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -51,3 +51,10 @@ spec:
                   secretKeyRef:
                     name: usdf-prompt-processing-creds
                     key: password
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              valueFrom:
+                  secretKeyRef:
+                    name: s3-credentials
+                    key: s3_credentials_ini_file
+            - name: S3_ENDPOINT_URL
+              value: https://s3dfrgw.slac.stanford.edu

--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -18,17 +18,29 @@ spec:
         - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:latest
           env:
             - name: RUBIN_INSTRUMENT
-              value: "lsst.obs.subaru.HyperSuprimeCam"
+              value: "HSC"
             - name: PUBSUB_VERIFICATION_TOKEN
               value: "rubin-prompt-proto-main"
             - name: IMAGE_BUCKET
-              value: "rubin-prompt-proto-main"
+              value: "rubin-pp"
             - name: CALIB_REPO
-              value: "gs://rubin-prompt-proto-main/central_repo/butler-ip.yaml"
+              value: "s3://rubin-pp-users/central_repo/"
             - name: IP_APDB
-              value: "10.109.19.42"
+              # Need explicit port for make_pgpass.py
+              value: "usdf-prompt-processing-dev.slac.stanford.edu:5432"
+            - name: DB_APDB
+              value: "rubin-devl"
+            - name: USER_APDB
+              value: "rubin"
+            - name: NAMESPACE_APDB
+              value: "pp_apdb"
             - name: IP_REGISTRY
-              value: "10.229.96.5:5432"
+              # Need explicit port for make_pgpass.py
+              value: "usdf-prompt-processing-dev.slac.stanford.edu:5432"
+            - name: DB_REGISTRY
+              value: "ppcentralbutler"
+            - name: USER_REGISTRY
+              value: "pp"
             - name: PSQL_REGISTRY_PASS
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This PR updates the `prompt-processing` environment variables to current USDF values, incorporating changes from lsst-dm/prompt_prototype#27.

~One outstanding issue is how to configure the Butler so that it can access the S3 central repo. On `rubin-devl`, this needs to be done by setting `S3_ENDPOINT_URL` and `AWS_PROFILE`. On Google, storage access was handled externally through service account permissions.~ Discussed on Slack; handled externally through makefile.