### PR TITLE
Fix handling of concurrent requests in prompt-proto-service.

### DIFF
--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -8,14 +8,14 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
-        autoscaling.knative.dev/target: "1"
         autoscaling.knative.dev/min-scale: "1"
         autoscaling.knative.dev/max-scale: "100"
+        autoscaling.knative.dev/target-utilization-percentage: "80"
         # Update this field if `make apply` by itself doesn't make a new revision.
         revision: "31"
       creationTimestamp: null
     spec:
-      containerConcurrency: 0
+      containerConcurrency: 1
       containers:
       - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:latest
         imagePullPolicy: Always


### PR DESCRIPTION
This is a cherry-pick of @dspeck1's experiments. Previously, work was being assigned to pods on a best-effort basis, causing jobs to pile up during scale-up instead of being assigned to the newly created pods. The new spec forbids assigning work to a pod that is already busy (though there may be still be a pile-up if the pod times out but continues processing).