### PR TITLE
DM-37253: Make Prompt Processing service configurable

### DIFF
--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -23,6 +23,8 @@ spec:
         env:
         - name: RUBIN_INSTRUMENT
           value: HSC
+        - name: PIPELINES_CONFIG
+          value: (survey="SURVEY")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
         - name: SKYMAP
           value: hsc_rings_v1
         - name: PUBSUB_VERIFICATION_TOKEN

--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containerConcurrency: 1
       containers:
-      - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:DM-38752-latest
+      - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:latest
         imagePullPolicy: Always
         name: user-container
         env:

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -24,6 +24,8 @@ spec:
         env:
         - name: RUBIN_INSTRUMENT
           value: LATISS
+        - name: PIPELINES_CONFIG
+          value: (survey="AUXTEL_PHOTO_IMAGING")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
         - name: SKYMAP
           value: latiss_v1
         - name: PUBSUB_VERIFICATION_TOKEN


### PR DESCRIPTION
This PR a pipeline configuration variable (`PIPELINES_CONFIG`) to the service setup. It is parsed by the code added on lsst-dm/prompt_prototype#71.