### PR TITLE
DM-39678: Allow Prompt Prototype to be configured with no pipeline

### DIFF
--- a/applications/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/applications/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containerConcurrency: {{ .Values.containerConcurrency }}
       containers:
-      - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:DM-38752-latest
+      - image: us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service:latest
         imagePullPolicy: Always
         name: user-container
         env:

--- a/applications/prompt-proto-service/templates/prompt-proto-service.yaml
+++ b/applications/prompt-proto-service/templates/prompt-proto-service.yaml
@@ -22,6 +22,8 @@ spec:
         env:
         - name: RUBIN_INSTRUMENT
           value: {{ .Values.instrument.name }}
+        - name: PIPELINES_CONFIG
+          value: {{ .Values.instrument.pipelines }}
         - name: SKYMAP
           value: {{ .Values.instrument.skymap }}
         - name: PUBSUB_VERIFICATION_TOKEN

--- a/applications/prompt-proto-service/values-hsc-usdfdev.yaml
+++ b/applications/prompt-proto-service/values-hsc-usdfdev.yaml
@@ -5,6 +5,7 @@
 
 instrument:
   name: HSC
+  pipelines: (survey="SURVEY")=${PROMPT_PROTOTYPE_DIR}/pipelines/HSC/ApPipe.yaml
   skymap: hsc_rings_v1
   calibRepo: s3://rubin-pp-users/central_repo/
 

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -25,7 +25,14 @@ spec:
         - name: RUBIN_INSTRUMENT
           value: LATISS
         - name: PIPELINES_CONFIG
-          value: (survey="AUXTEL_PHOTO_IMAGING")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
+          value: >
+            (survey="AUXTEL_PHOTO_IMAGING")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
+            (survey="spec")=None
+            (survey="spec_with_rotation")=None
+            (survey="spec_bright")=None
+            (survey="spec_bright_with_rotation")=None
+            (survey="spec_pole")=None
+            (survey="spec_pole_with_rotation")=None
         - name: SKYMAP
           value: latiss_v1
         - name: PUBSUB_VERIFICATION_TOKEN


### PR DESCRIPTION
This PR updates the production service config to ignore spectroscopic AuxTel observations. It also makes a few patches to reconcile #29 and #30.

This PR must not be merged before lsst-dm/prompt_prototype#72, which adds the code to correctly parse `None` pipeline values.