### PR TITLE
Remove references to AuxTel20230524-w_2023_20 tag.

### DIFF
--- a/applications/prompt-proto-service/values-hsc-usdfdev.yaml
+++ b/applications/prompt-proto-service/values-hsc-usdfdev.yaml
@@ -7,7 +7,7 @@ image:
   repository: ghcr.io/lsst-dm/prompt-proto-service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: AuxTel20230524-w_2023_20
+  tag: d_2023_07_11
 
 instrument:
   name: HSC

--- a/applications/prompt-proto-service/values-latiss-usdfdev.yaml
+++ b/applications/prompt-proto-service/values-latiss-usdfdev.yaml
@@ -7,7 +7,7 @@ image:
   repository: ghcr.io/lsst-dm/prompt-proto-service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: AuxTel20230524-w_2023_20
+  tag: d_2023_07_11
 
 instrument:
   name: LATISS

--- a/applications/prompt-proto-service/values-latiss-usdfprod.yaml
+++ b/applications/prompt-proto-service/values-latiss-usdfprod.yaml
@@ -7,7 +7,7 @@ image:
   repository: ghcr.io/lsst-dm/prompt-proto-service
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: AuxTel20230524-w_2023_20
+  tag: d_2023_07_11
 
 instrument:
   name: LATISS

--- a/kubernetes/overlays/dev/prompt-proto-service/latiss/kustomization.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/latiss/kustomization.yaml
@@ -16,7 +16,7 @@ namePrefix:
 images:
 - name: ghcr.io/lsst-dm/prompt-proto-service:TAG
   newName: ghcr.io/lsst-dm/prompt-proto-service
-  newTag: AuxTel20230509-d_2023_05_01
+  newTag: d_2023_07_11
 
 secretGenerator:
 

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -109,13 +109,13 @@ spec:
           requests:
             ephemeral-storage: "8Gi"
           limits:
-            ephemeral-storage: "20Gi"
+            ephemeral-storage: "30Gi"
       volumes:
       - name: central-repo-file
         secret:
           secretName: central-repo-file3
       - name: ephemeral
         emptyDir:
-          sizeLimit: "20Gi"
+          sizeLimit: "30Gi"
       enableServiceLinks: false
       timeoutSeconds: 900

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containerConcurrency: 1
       containers:
-      - image: ghcr.io/lsst-dm/prompt-proto-service:AuxTel20230524-w_2023_20
+      - image: ghcr.io/lsst-dm/prompt-proto-service:d_2023_07_11
         imagePullPolicy: Always
         name: user-container
         env:


### PR DESCRIPTION
The `AuxTel20230524-w_2023_20` tag was used to deploy some special commits for the late May AuxTel run. Now that all those changes have been merged to `main`, we should use the `latest` build by default again.