### PR TITLE
Remove vestigial Docker secret from prod deployment

### DIFF
--- a/kubernetes/overlays/prod/prompt-proto-service/Makefile
+++ b/kubernetes/overlays/prod/prompt-proto-service/Makefile
@@ -26,7 +26,7 @@ clean-secrets:
 create-singularity:
 	singularity pull -F docker://quay.io/strimzi/kafka:0.31.1-kafka-3.2.3
 
-producer: 
+producer:
 	singularity exec $(SINGULARITY_IMAGE) /opt/kafka/bin/kafka-console-producer.sh --bootstrap-server $(BOOTSTRAP_SERVER) --topic $(KAFKA_TOPIC)
 
 run-kustomize:

--- a/kubernetes/overlays/prod/prompt-proto-service/Makefile
+++ b/kubernetes/overlays/prod/prompt-proto-service/Makefile
@@ -20,9 +20,6 @@ get-secrets-from-vault:
 	mkdir -p etc/.secrets/s3/
 	set -e; for i in access_key secret_key; do vault kv get --field=$$i $(S3_SECRET_PATH) > etc/.secrets/s3/$$i ; done
 
-	mkdir -p etc/.secrets/docker/
-	set -e; for i in .dockerconfigjson; do vault kv get --field=$$i $(DOCKER_SECRET_PATH) > etc/.secrets/docker/$$i ; done
-
 clean-secrets:
 	rm -rf etc/.secrets/
 

--- a/kubernetes/overlays/prod/prompt-proto-service/kustomization.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/kustomization.yaml
@@ -27,12 +27,3 @@ secretGenerator:
   files:
   - etc/.secrets/s3/access_key
   - etc/.secrets/s3/secret_key
-
-- name: regcred
-  options:
-    disableNameSuffixHash: true
-  files:
-  - etc/.secrets/docker/.dockerconfigjson
-  type: kubernetes.io/dockerconfigjson
-
-


### PR DESCRIPTION
The secret was needed for the Google container registry, which is no longer being used. The secret's location was removed in #36, but there was still code that assumed it was needed.