### PR TITLE
sasquatch schema registry IP fix

### DIFF
--- a/kubernetes/overlays/prod/next-visit-fan-out/next-visit-fan-out-deployment.yaml
+++ b/kubernetes/overlays/prod/next-visit-fan-out/next-visit-fan-out-deployment.yaml
@@ -50,7 +50,7 @@ spec:
                   key: kafka_pp_sasl_password
                   name: kafka-sasl-prompt-prompt-processing
             - name: KAFKA_SCHEMA_REGISTRY_URL
-              value: http://10.101.114.201:8081
+              value: http://10.106.41.77:8081
             - name: OFFSET
               value: latest
       volumes:


### PR DESCRIPTION
Change value for sasquatch schema registry.  The service is only available via IP right now and is on a separate k8s cluster.