### PR TITLE
DM-39655: Use a list of "fallback" pipelines in Prompt Processing

### DIFF
--- a/applications/prompt-proto-service/values-hsc-usdfdev.yaml
+++ b/applications/prompt-proto-service/values-hsc-usdfdev.yaml
@@ -11,7 +11,7 @@ image:
 
 instrument:
   name: HSC
-  pipelines: (survey="SURVEY")=${PROMPT_PROTOTYPE_DIR}/pipelines/HSC/ApPipe.yaml
+  pipelines: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/HSC/ApPipe.yaml]
   skymap: hsc_rings_v1
   calibRepo: s3://rubin-pp-users/central_repo/
 

--- a/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/dev/prompt-proto-service/prompt-proto-service.yaml
@@ -24,7 +24,7 @@ spec:
         - name: RUBIN_INSTRUMENT
           value: HSC
         - name: PIPELINES_CONFIG
-          value: (survey="SURVEY")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
+          value: (survey="SURVEY")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
         - name: SKYMAP
           value: hsc_rings_v1
         - name: PUBSUB_VERIFICATION_TOKEN

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -29,6 +29,9 @@ spec:
             (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml,
                                              ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/SingleFrame.yaml,
                                              ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/Isr.yaml]
+            (survey="AUXTEL_DRP_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml,
+                                           ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/SingleFrame.yaml,
+                                           ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/Isr.yaml]
             (survey="spec")=[]
             (survey="spec_with_rotation")=[]
             (survey="spec_bright")=[]

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -26,7 +26,9 @@ spec:
           value: LATISS
         - name: PIPELINES_CONFIG
           value: >
-            (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
+            (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml,
+                                             ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/SingleFrame.yaml,
+                                             ${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/Isr.yaml]
             (survey="spec")=[]
             (survey="spec_with_rotation")=[]
             (survey="spec_bright")=[]

--- a/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
+++ b/kubernetes/overlays/prod/prompt-proto-service/prompt-proto-service.yaml
@@ -26,14 +26,14 @@ spec:
           value: LATISS
         - name: PIPELINES_CONFIG
           value: >
-            (survey="AUXTEL_PHOTO_IMAGING")=${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml
-            (survey="spec")=None
-            (survey="spec_with_rotation")=None
-            (survey="spec_bright")=None
-            (survey="spec_bright_with_rotation")=None
-            (survey="spec_pole")=None
-            (survey="spec_pole_with_rotation")=None
-            (survey="")=None
+            (survey="AUXTEL_PHOTO_IMAGING")=[${PROMPT_PROTOTYPE_DIR}/pipelines/${RUBIN_INSTRUMENT}/ApPipe.yaml]
+            (survey="spec")=[]
+            (survey="spec_with_rotation")=[]
+            (survey="spec_bright")=[]
+            (survey="spec_bright_with_rotation")=[]
+            (survey="spec_pole")=[]
+            (survey="spec_pole_with_rotation")=[]
+            (survey="")=[]
         - name: SKYMAP
           value: latiss_v1
         - name: PUBSUB_VERIFICATION_TOKEN


### PR DESCRIPTION
This PR updates the service configurations to use the new pipeline syntax introduced in lsst-dm/prompt_prototype#75. This is a breaking change, so both PRs must be merged together.