### PR TITLE
GHCR prod next visit image change and update consumer group name

### DIFF
--- a/kubernetes/overlays/prod/next-visit-fan-out/Makefile
+++ b/kubernetes/overlays/prod/next-visit-fan-out/Makefile
@@ -1,12 +1,8 @@
 SECRET_PATH ?= secret/rubin/usdf-prompt-processing/next-visit-fan-out
-DOCKER_SECRET_PATH ?= secret/rubin/usdf-prompt-processing/docker
 
 get-secrets-from-vault:
 	mkdir -p etc/.secrets/
 	set -e; for i in kafka_pp_sasl_password kafka_pp_sasl_username; do vault kv get --field=$$i $(SECRET_PATH) > etc/.secrets/$$i ; done
-	
-	mkdir -p etc/.secrets/docker/
-	set -e; for i in .dockerconfigjson; do vault kv get --field=$$i $(DOCKER_SECRET_PATH) > etc/.secrets/docker/$$i ; done
 
 clean-secrets:
 	rm -rf etc/.secrets/

--- a/kubernetes/overlays/prod/next-visit-fan-out/kustomization.yaml
+++ b/kubernetes/overlays/prod/next-visit-fan-out/kustomization.yaml
@@ -13,11 +13,3 @@ secretGenerator:
   files:
   - etc/.secrets/kafka_pp_sasl_username
   - etc/.secrets/kafka_pp_sasl_password
-
-- name: regcred
-  options:
-    disableNameSuffixHash: true
-  files:
-  - etc/.secrets/docker/.dockerconfigjson
-  type: kubernetes.io/dockerconfigjson
-

--- a/kubernetes/overlays/prod/next-visit-fan-out/next-visit-fan-out-deployment.yaml
+++ b/kubernetes/overlays/prod/next-visit-fan-out/next-visit-fan-out-deployment.yaml
@@ -15,11 +15,10 @@ spec:
       labels:
         app: next-visit-fan-out
     spec:
-      imagePullSecrets:
-        - name: regcred
       containers:
         - name: nextvisit-start
-          image: us-central1-docker.pkg.dev/prompt-proto/prompt/nextvisit-fanout:v1.70
+          image: ghcr.io/lsst-dm/next_visit_fan_out:main
+          imagePullPolicy: Always
           env:
             - name: LATISS_KNATIVE_SERVING_URL
               value: http://prompt-proto-service.prompt-proto-service/next-visit
@@ -32,7 +31,7 @@ spec:
             - name: KAFKA_CLUSTER
               value: 10.104.21.0:9094
             - name: CONSUMER_GROUP
-              value: test-group-1
+              value: next-visit-fan-out-1
             - name: NEXT_VISIT_TOPIC
               value: lsst.sal.ScriptQueue.logevent_nextVisit
             - name: SASL_MECHANISM


### PR DESCRIPTION
Update makefile, kustomize, and deployment manifest for ghcr image.   Remove test from consumer group name and add next visit fan out to name for easier debugging later.