### PR TITLE
Increase max database connections in dev

### DIFF
--- a/kubernetes/overlays/dev/database/cnpg-database.yaml
+++ b/kubernetes/overlays/dev/database/cnpg-database.yaml
@@ -39,7 +39,7 @@ spec:
       shared_buffers: 2GB
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
-      max_connections: "2000"
+      max_connections: "3000"
       log_disconnections: "on"
       log_duration: "on"
       log_statement: all

--- a/kubernetes/overlays/dev/database/cnpg-pooler.yaml
+++ b/kubernetes/overlays/dev/database/cnpg-pooler.yaml
@@ -11,8 +11,8 @@ spec:
   pgbouncer:
     poolMode: session
     parameters:
-      max_client_conn: "2000"
-      default_pool_size: "1500"
+      max_client_conn: "3000"
+      default_pool_size: "2500"
       log_connections: "1"
       log_disconnections: "1"
       idle_transaction_timeout: "0"


### PR DESCRIPTION
Increase max dev database connections and pooler limits due to connection limit failures from stress testing.